### PR TITLE
feat: add cherfia/jotenberg java client

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
 * 🚀 [TypeScript - cherfia/chromiumly](https://github.com/cherfia/chromiumly)
 * 🚀 [C# - ChangemakerStudios/GotenbergSharpApiClient](https://github.com/ChangemakerStudios/GotenbergSharpApiClient)
 * 🚀 [Ruby - jbd0101/ruby-gotenberg-client](https://github.com/jbd0101/ruby-gotenberg-client)
+* 🚀 [Java - cherfia/jotenberg](https://github.com/cherfia/jotenberg)
 * [JavaScript/TypeScript - yumauri/gotenberg-js-client](https://github.com/yumauri/gotenberg-js-client) - Gotenberg **6.x** ⚠️
 * [Go - thecodingmachine/gotenberg-go-client](https://github.com/thecodingmachine/gotenberg-go-client) - Gotenberg **6.x** ⚠️
 * [PHP - thecodingmachine/gotenberg-php-client](https://github.com/thecodingmachine/gotenberg-php-client) - Gotenberg **6.x** ⚠️


### PR DESCRIPTION
### Summary
[Jotenberg](https://github.com/cherfia/jotenberg) is a Java library that provides a fully fledge client which interacts with different modules of Gotenberg to convert a variety of document formats to PDF files.

### Motivation

The only Java-related implementation is the [Java Cookbook](https://gist.github.com/rsoika/0cae2fa63a565ec4698bce13f243118d) utility class which is a great starting point to showcase how to use Java with Gotenberg, however, it does not support the latest Gotenberg version and the developer must implement the rest of functionality in order to interact with the different modules of Gotenberg.