### PR TITLE
Add document template processing service project

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@
 * [jonaswinkler/paperless-ng](https://github.com/jonaswinkler/paperless-ng) - an application that indexes your scanned documents and allows you to easily search for documents and store metadata alongside your documents.
 * [SCM-Manager](https://scm-manager.org/) - an application to share and manage your Git, Mercurial and Subversion repositories, with a [Gotenberg](https://scm-manager.org/plugins/scm-gotenberg-plugin/) plugin. See also their [blog post](https://scm-manager.org/blog/posts/2021-11-17-scm-manager-2-27-0/).
 * [Corteza](https://cortezaproject.org/) - a free, open-source, Low Code platform for building your organisation’s key applications. They use [Gotenberg](https://docs.cortezaproject.org/corteza-docs/2021.9/devops-guide/extension-requirements/pdf-renderer.html) for PDF rendering.
-* [papihack/document-templating-service](https://github.com/PapiHack/document-templating-service) - A lightweight microservice for processing your documents, powered by a templating engine for injecting variables defined in it and use Gotenberg for PDF rendering.
+* [papihack/document-templating-service](https://github.com/PapiHack/document-templating-service) - a lightweight microservice for processing your documents, powered by a templating engine for injecting variables defined in it and use Gotenberg for PDF rendering.
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@
 * [jonaswinkler/paperless-ng](https://github.com/jonaswinkler/paperless-ng) - an application that indexes your scanned documents and allows you to easily search for documents and store metadata alongside your documents.
 * [SCM-Manager](https://scm-manager.org/) - an application to share and manage your Git, Mercurial and Subversion repositories, with a [Gotenberg](https://scm-manager.org/plugins/scm-gotenberg-plugin/) plugin. See also their [blog post](https://scm-manager.org/blog/posts/2021-11-17-scm-manager-2-27-0/).
 * [Corteza](https://cortezaproject.org/) - a free, open-source, Low Code platform for building your organisation’s key applications. They use [Gotenberg](https://docs.cortezaproject.org/corteza-docs/2021.9/devops-guide/extension-requirements/pdf-renderer.html) for PDF rendering.
+* [papihack/document-templating-service](https://github.com/PapiHack/document-templating-service) - A lightweight microservice for processing your documents, powered by a templating engine for injecting variables defined in it and use Gotenberg for PDF rendering.
 
 ## Resources
 


### PR DESCRIPTION
Hello, hope you're doing well.

## Summary
[Document template processing service](https://github.com/PapiHack/document-templating-service) is simple and lightweight service that allows you to process your documents with the variables defined therein by injecting the necessary data that you will provide and return the result in PDF.

## Motivation
During a project whose architecture was microservices-oriented, we wanted to decouple the processing (templating, pdf rendering, etc.) of documents such as invoices, contracts from other microservices.
We found the excellent gotenberg for pdf rendering that we could combine with a light service allowing to inject data into documents before rendering them in pdf format.
This is the open source version of the use case implementation.