### PR TITLE
Add SensioLabs's GotenbergBundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@
 * 🚀 [Java - cherfia/jotenberg](https://github.com/cherfia/jotenberg)
 * 🚀 [Kotlin - marrek13/kotenberg](https://github.com/marrek13/kotenberg)
 * 🚀 [Go - dcaraxes/gotenberg-go-client](https://github.com/dcaraxes/gotenberg-go-client)
+* [PHP/Symfony - sensiolabs/gotenberg-bundle](https://github.com/sensiolabs/gotenberg-bundle) - Gotenberg **8.x**
 * [JavaScript/TypeScript - yumauri/gotenberg-js-client](https://github.com/yumauri/gotenberg-js-client) - Gotenberg **6.x** ⚠️
 * [Go - thecodingmachine/gotenberg-go-client](https://github.com/thecodingmachine/gotenberg-go-client) - Gotenberg **6.x** ⚠️
 * [PHP - thecodingmachine/gotenberg-php-client](https://github.com/thecodingmachine/gotenberg-php-client) - Gotenberg **6.x** ⚠️


### PR DESCRIPTION
Hey. We created a Bundle to better integrate Gotenberg in the Symfony ecosystem. With @Jean-Beru we gave a talk at SymfonyCon 2024 ((slides)[https://neirda24.github.io/talk-sfcon-2024-vienna-gotenberg/1]) showcasing how we create a Bundle.

@StevenRenaux also create (an article on the basics of how to use this bundle)[https://medium.com/the-sensiolabs-tech-blog/how-to-generate-a-pdf-file-in-a-few-lines-of-code-with-symfony-39786a679d29].

The bundle is still experimental and will have some internal changes. The public API should not change much. We are planning to integrate more components (like Webhook for example which is still WIP at the moment).